### PR TITLE
Automated releases to github container registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - "*"
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - '*'
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - "*"
     tags:
       - 'v*'
 
@@ -22,11 +24,11 @@ jobs:
             echo "TAGNAME=$(basename ${{ github.ref }})" >> $GITHUB_ENV
 
       - name: Build image
-        run: docker build -t ghcr.io/mfitzpatrick/mplabx-build:${{ env.TAGNAME }} .
+        run: docker build -t ghcr.io/${{ github.repository }}:${{ env.TAGNAME }} .
 
       - name: Login to github container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
-        run: docker push ghcr.io/${{ github.repository_owner }}/mplabx-build:${{ env.TAGNAME }}
+        run: docker push ghcr.io/${{ github.repository }}:${{ env.TAGNAME }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
             echo "TAGNAME=$(basename ${{ github.ref }})" >> $GITHUB_ENV
 
       - name: Build image
-        run: docker build -t $TAGNAME .
+        run: docker build -t ghcr.io/mfitzpatrick/mplabx-build:${{ env.TAGNAME }} .
 
       - name: Push image
-        run: docker push ghcr.io/mfitzpatrick/mplabx-build:$TAGNAME
+        run: docker push ghcr.io/mfitzpatrick/mplabx-build:${{ env.TAGNAME }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build image
         run: docker build -t ghcr.io/mfitzpatrick/mplabx-build:${{ env.TAGNAME }} .
 
+      - name: Login to github container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Push image
-        run: docker push ghcr.io/mfitzpatrick/mplabx-build:${{ env.TAGNAME }}
+        run: docker push ghcr.io/${{ github.repository_owner }}/mplabx-build:${{ env.TAGNAME }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# Build the docker image and push to github container registry
+
+name: Release
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Use the shell to generate custom environment variables that cannot be
+      # natively configured in this YAML file
+      - name: Build custom env
+        id: custom_env
+        run: |
+            echo "TAGNAME=$(basename ${{ github.ref }})" >> $GITHUB_ENV
+
+      - name: Build image
+        run: docker build -t $TAGNAME .
+
+      - name: Push image
+        run: docker push ghcr.io/mfitzpatrick/mplabx-build:$TAGNAME
+

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ https://hub.docker.com/r/dataspeedinc/mplabx
 It has been modified to support the XC8 compiler.
 
 ## Getting Started
-This docker image is available on docker hub.
+This docker image is available on github container registry.
 ```
-docker pull mpfitzpatrick/mplabx-build:latest
+docker pull ghcr.io/mfitzpatrick/mplabx-build:<tag name>
 ```
 
 To build your firmware, add it as a volume to the docker container when it is run:

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ To build your firmware, add it as a volume to the docker container when it is ru
 ```
 docker run --rm -v $PWD:/pic mpfitzpatrick/mplabx-build
 ```
+
+# Releases
+Docker Hub has recently changed its policy and stopped automated builds linked to open-source
+repositories from working by default. For simplicity, this has now been moved over to Github
+Container Registry. Follow the link to the github repository, and search for updated images
+in the releases section.
+


### PR DESCRIPTION
Docker hub changed its policy recently to disallow automated builds even if the repository is open-source. Images can still be pushed to docker hub, but it specifically refuses to build things anymore.

This PR adds in a new YAML file which configures building with Github Actions. This will build the docker image and push it to Github Container Registry, where it can be freely downloaded.